### PR TITLE
do not plot correct simulations; reduce atol increase rtol

### DIFF
--- a/src/suite.jl
+++ b/src/suite.jl
@@ -54,10 +54,10 @@ function verify_case(dir;saveplot=false)
         sol = solve(prob, CVODE_BDF(); abstol=settings["absolute"], reltol=settings["relative"])
         solm = Array(sol)'
         m = Matrix(results[1:end-1, 2:end])[:, sortperm(sortperm(statenames))]
-        res = isapprox(solm, m; atol=1e-2)
+        res = isapprox(solm, m; atol=1e-9, rtol=3e-2)
         diff = m .- solm
         atol = maximum(diff)
-        saveplot && verify_plot(case_no, rs, solm, m)
+        saveplot && !res && verify_plot(case_no, rs, solm, m)
         return [dir, res, atol, err]
     catch e
         err = string(e)


### PR DESCRIPTION
The last version of main plotted either all or none simulation results. I think the ones of primary interest are the wrong results. We could also think of passing Strings to the `saveplot` argument ("all", "wrong", "correct", "none").